### PR TITLE
Add `export` command

### DIFF
--- a/onetimepass/db/json_encrypted.py
+++ b/onetimepass/db/json_encrypted.py
@@ -38,4 +38,4 @@ class JSONEncryptedDB(BaseDB):
 
     def write(self, data: DatabaseSchema):
         with open(self.path, "wb") as f:
-            f.write(self.fernet.encrypt(json.dumps(data.dict()).encode()))
+            f.write(self.fernet.encrypt(data.json().encode()))

--- a/onetimepass/db/models.py
+++ b/onetimepass/db/models.py
@@ -1,37 +1,50 @@
 from __future__ import annotations
 
+import datetime
+import enum
 import typing
 
 from pydantic import BaseModel
+from pydantic import validator
 
 from onetimepass.settings import DB_VERSION
 
 
 """
-Example database schema
+# Example database schema
+
+## If just initialized
+
+```json
 {
   "otp": {},
   "version": "<DB_VERSION>",
+}
+```
 
-  or
+## After adding some secrets
 
+```json
+}
   "otp": {
     "keeper": {
       "secret": "",
       "digits_count": 0,
       "hash_algorithm": "",
       "params": {
-        // hopt
+        otp_type: "HOTP|TOTP",
+        // if otp_type == HOTP
         "counter": 0,
 
-        // topt
-        "initial_time": 0,
+        // if otp_type == TOTP
+        "initial_time": "1970-01-01T00:00:00+00:00",
         "time_step_seconds": 30
       }
     }
   },
   "version": "<DB_VERSION>"
 }
+```
 """
 
 
@@ -44,15 +57,35 @@ class HOTPParams(BaseModel):
 
 
 class TOTPParams(BaseModel):
-    initial_time: int
+    initial_time: datetime.datetime
     time_step_seconds: int
+
+
+class OTPType(str, enum.Enum):
+    HOTP = "HOTP"
+    TOTP = "TOTP"
 
 
 class AliasSchema(BaseModel):
     secret: str
     digits_count: int
     hash_algorithm: str
-    params: typing.Union[HOTPParams, TOTPParams]
+    otp_type: OTPType
+    params: typing.Union[
+        HOTPParams, TOTPParams
+    ]  # Type depends on the value of `otp_type`, see the validator
+
+    @validator("params")
+    def valid_params_for_otp_type(cls, v, values):
+        otp_type = values["otp_type"]
+        required_param_type_by_otp_type = {
+            OTPType.HOTP: HOTPParams,
+            OTPType.TOTP: TOTPParams,
+        }
+        for key, value in required_param_type_by_otp_type.items():
+            if otp_type == key and not isinstance(v, value):
+                raise TypeError(f"{otp_type=} requires params of type {HOTPParams}")
+        return v
 
 
 class DatabaseSchema(BaseModel):
@@ -69,13 +102,14 @@ class DatabaseSchema(BaseModel):
         secret: str,
         digits_count: int,
         hash_algorithm: str,
-        initial_time: int,
+        initial_time: datetime.datetime,
         time_step_seconds: int = 30,
     ):
         self.otp[name] = AliasSchema(
             secret=secret,
             digits_count=digits_count,
             hash_algorithm=hash_algorithm,
+            otp_type=OTPType.TOTP,
             params=TOTPParams(
                 initial_time=initial_time, time_step_seconds=time_step_seconds,
             ),

--- a/onetimepass/exceptions.py
+++ b/onetimepass/exceptions.py
@@ -1,0 +1,7 @@
+class BaseApplicationException(Exception):
+    pass
+
+
+class UnhandledFormatException(BaseApplicationException):
+    def __init__(self, format_):
+        super().__init__(format_)


### PR DESCRIPTION
Also, improve database models:
- Fix TOTP's `initial_time` having `int` type instead of `datetime`.
- Support `otp_type` parameter.
- Validate `params` based on the `otp_type` value.
- Use `pydantic.BaseModel.json()` built-in serialization (supports
  `datetime` serialization out-of-the-box.