### PR TITLE
Standardize some commands names

### DIFF
--- a/onetimepass/otp.py
+++ b/onetimepass/otp.py
@@ -164,7 +164,7 @@ def key(ctx: click.Context):
     click.echo(key_)
 
 
-@otp.command(help="Remove the secret for the specified ALIAS.")
+@otp.command("rm", help="Remove the secret for the specified ALIAS.")
 @click.argument("alias")
 @click.confirmation_option(prompt="Are you sure?")
 @click.pass_context
@@ -270,7 +270,7 @@ def add(
         click.echo(f"{alias} added")
 
 
-@otp.command(help="Rename the specified ALIAS.")
+@otp.command("mv", help="Rename the specified ALIAS.")
 @click.argument("old_alias")
 @click.argument("new_alias")
 @click.pass_context


### PR DESCRIPTION
- `otp rm` like `git rm`, instead of `otp delete`.
- `otp mv` like `git mv`, instead of `otp rename`.

This should make the UI potentially more intuitive for the hardcode CLI
users.