### PR TITLE
Fix issue #26

### DIFF
--- a/onetimepass/db/__init__.py
+++ b/onetimepass/db/__init__.py
@@ -1,5 +1,6 @@
 from .base import BaseDB
 from .exceptions import BaseDBException
+from .exceptions import DBAlreadyInitialized
 from .exceptions import DBCorruption
 from .exceptions import DBDoesNotExist
 from .exceptions import DBMergeConflict
@@ -12,11 +13,12 @@ from .models import DatabaseSchema
 __all__ = [
     "BaseDB",
     "BaseDBException",
+    "DBAlreadyInitialized",
+    "DBCorruption",
     "DBDoesNotExist",
     "DBMergeConflict",
     "DBUnsupportedMigration",
     "DBUnsupportedVersion",
     "DatabaseSchema",
     "JSONEncryptedDB",
-    "DBCorruption",
 ]

--- a/onetimepass/db/base.py
+++ b/onetimepass/db/base.py
@@ -1,9 +1,13 @@
+import abc
+
 from .models import DatabaseSchema
 
 
-class BaseDB:
+class BaseDB(abc.ABC):
+    @abc.abstractmethod
     def read(self) -> DatabaseSchema:
-        raise NotImplementedError
+        pass
 
+    @abc.abstractmethod
     def write(self, data: DatabaseSchema):
-        raise NotImplementedError
+        pass

--- a/onetimepass/db/exceptions.py
+++ b/onetimepass/db/exceptions.py
@@ -1,3 +1,5 @@
+import pathlib
+
 from onetimepass import settings
 
 
@@ -12,6 +14,11 @@ class DBCorruption(BaseDBException):
 
 class DBDoesNotExist(BaseDBException):
     pass
+
+
+class DBAlreadyInitialized(BaseDBException):
+    def __init__(self, path: pathlib.Path):
+        super().__init__(f"The local database `{path}` is already initialized")
 
 
 class DBUnsupportedVersion(BaseDBException):

--- a/onetimepass/db/json_encrypted.py
+++ b/onetimepass/db/json_encrypted.py
@@ -6,36 +6,36 @@ import pathlib
 from cryptography.fernet import Fernet
 
 from .base import BaseDB
+from .exceptions import DBAlreadyInitialized
 from .exceptions import DBDoesNotExist
 from .models import DatabaseSchema
 
 
 class JSONEncryptedDB(BaseDB):
-    def __init__(self, path: str, key: bytes):
+    def __init__(self, path: pathlib.Path, key: bytes):
         self.path = path
         self.key = key
         self.fernet = Fernet(key)
 
     @classmethod
-    def initialize(cls, path: str) -> JSONEncryptedDB:
+    def initialize(cls, path: pathlib.Path) -> JSONEncryptedDB:
         """Generate key and initialize empty database"""
+        if path.exists():
+            raise DBAlreadyInitialized(path)
         key = Fernet.generate_key()
         db = cls(path=path, key=key)
         data = DatabaseSchema.initialize()
+        db.path.parent.mkdir(parents=True, exist_ok=True)
         db.write(data)
         return db
 
-    @classmethod
-    def exists(cls, path: str) -> bool:
-        return pathlib.Path(path).exists()
-
     def read(self) -> DatabaseSchema:
-        if not self.exists(self.path):
+        if not self.path.exists():
             raise DBDoesNotExist()
-        with open(self.path, "rb") as f:
+        with self.path.open("rb") as f:
             data = self.fernet.decrypt(f.read())
         return DatabaseSchema(**json.loads(data))
 
     def write(self, data: DatabaseSchema):
-        with open(self.path, "wb") as f:
+        with self.path.open("wb") as f:
             f.write(self.fernet.encrypt(data.json().encode()))

--- a/onetimepass/settings.py
+++ b/onetimepass/settings.py
@@ -1,6 +1,10 @@
 import logging
 
-DB_PATH = "test.db"
+import platformdirs
+
+APP_NAME = "onetimepass"
+
+DB_PATH = platformdirs.user_data_path(APP_NAME) / "onetimepass.db"
 DEFAULT_DB_VERSION = "1.0.0"
 SUPPORTED_DB_VERSION = [
     DEFAULT_DB_VERSION,
@@ -9,7 +13,7 @@ DEFAULT_HASH_ALGORITHM = "sha1"
 DEFAULT_DIGITS_COUNT = 6
 DEFAULT_TIME_STEP_SECONDS = 30
 
-KEYRING_SERVICE_NAME = "onetimepass"
+KEYRING_SERVICE_NAME = APP_NAME
 KEYRING_USERNAME = "master key"
 
 LOG_LEVEL = (

--- a/pdm.lock
+++ b/pdm.lock
@@ -207,7 +207,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:08789845a2f9aeb6c7f242c8d744cde2f2c634d90770cc1e8eef96a1ab6af9d9"
+content_hash = "sha256:2016d6cb2fdf1ae51c6db6167a9fc444c92eae6a43f970785cea9ef3980f27a1"
 
 [metadata.files]
 "backports.entry-points-selectable 1.1.1" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pydantic~=1.8",
     "cryptography~=36.0",
     "rich~=10.15",
+    "platformdirs~=2.4",
 ]
 requires-python = ">=3.10"
 dynamic = ["version"]


### PR DESCRIPTION
Now, the app stores a local database in the OS-specific data directory.

This commit also improves the overall code quality:

Best practice:
- `abc` module is used to implement abstract classes.
- `pathlib` is used for the file paths, not `str`.
- Exception handling in the `init` command is now more granular.

Encapsulation:
- Checking if the database already exists is now the responsibility of
  the database module, not the command implementation.
- Redundant `JSONEncryptedDB.exists` classmethod was removed (it didn't
  do anything more than simple `self.path.exist`).

  I considered to replace it with the instance method, but that could be
  confusing (if the database requires both path and key to be created,
  does it check if the database with the specific path _and_ key
  exists?).