### PR TITLE
Fix #34

### DIFF
--- a/onetimepass/base_model.py
+++ b/onetimepass/base_model.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel as _BaseModel
+from pydantic import Extra
+
+
+class BaseModel(_BaseModel, extra=Extra.forbid):
+    pass

--- a/onetimepass/db/models.py
+++ b/onetimepass/db/models.py
@@ -83,6 +83,8 @@ class AliasSchema(BaseModel):
     params: typing.Union[
         HOTPParams, TOTPParams
     ]  # Type depends on the value of `otp_type`, see the validator
+    label: typing.Optional[str]
+    issuer: typing.Optional[str]
 
     @validator("params")
     def valid_params_for_otp_type(cls, v, values):

--- a/onetimepass/db/models.py
+++ b/onetimepass/db/models.py
@@ -4,10 +4,10 @@ import datetime
 import enum
 import typing
 
-from pydantic import BaseModel
 from pydantic import validator
 
 from onetimepass import settings
+from onetimepass.base_model import BaseModel
 from onetimepass.db import exceptions
 
 """

--- a/onetimepass/otp.py
+++ b/onetimepass/otp.py
@@ -396,8 +396,8 @@ def default_add_otp_options(fn):
 def add_hotp(
     ctx: click.Context,
     alias: str,
-    label: str,
-    issuer: str,
+    label: str | None,
+    issuer: str | None,
     algorithm: str,
     digits_count: int,
     counter: int,
@@ -452,8 +452,8 @@ def add_hotp(
 def add_totp(
     ctx: click.Context,
     alias: str,
-    label: str,
-    issuer: str,
+    label: str | None,
+    issuer: str | None,
     algorithm: str,
     digits_count: int,
     period: int,

--- a/onetimepass/otp_auth_uri.py
+++ b/onetimepass/otp_auth_uri.py
@@ -2,9 +2,8 @@ import datetime
 import typing
 import urllib.parse
 
-from pydantic import BaseModel
-
 from onetimepass import settings
+from onetimepass.base_model import BaseModel
 from onetimepass.db.models import get_params_by_type
 from onetimepass.db.models import HOTPParams
 from onetimepass.db.models import OTPAlgorithm

--- a/onetimepass/otp_auth_uri.py
+++ b/onetimepass/otp_auth_uri.py
@@ -15,8 +15,8 @@ SCHEMA = "otpauth"
 
 class OTPAuthURI(BaseModel):
     otp_type: OTPType
-    label: str
-    issuer: str
+    label: typing.Optional[str]
+    issuer: typing.Optional[str]
     secret: str
     algorithm: OTPAlgorithm
     digits: int


### PR DESCRIPTION
You can see in the changes, that I alternate between the `typing.Optional` and new union operator `|`, which introduces inconsistency.

This is because:
1. It seems the union operator `|` will be the preferred way to annotate the optionals: https://twitter.com/raymondh/status/1472426960349548549?s=20

    I think it makes sense, and tbh I like this syntax, so I decided to incorporate this preference into the project.
1. Unfortunately, Pydantic does not support the new union operator `|` at all yet: https://github.com/samuelcolvin/pydantic/issues/3300.

    I've tried the [suggested workaround](https://github.com/samuelcolvin/pydantic/issues/3300#issuecomment-950122191), but it didn't work.
    
    As such, I decided to use `typing.Optional` in the case of Pydantic models, as an exception to the consistency.

closes #34