### PR TITLE
Revert `click` issue workaround

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
-        additional_dependencies: ['click<=8.0.4']
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v3.0.1
     hooks:


### PR DESCRIPTION
As this was already fixed by the `black` itself.

See also: https://github.com/apptension/onetimepass/pull/49#issuecomment-1094040394.