### PR TITLE
Fix CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up PDM
-      uses: pdm-project/setup-pdm@v3.1
+      uses: pdm-project/setup-pdm@v3.3
       with:
         python-version: "3.10"
         architecture: x64


### PR DESCRIPTION
In `Set up PDM`:
```
Warning: Unexpected input(s) 'allow-python-prereleases', valid inputs are ['python-version', 'architecture', 'token', 'version', 'prerelease', 'enable-pep582', 'cache', 'cache-dependency-path']
Run pdm-project/setup-pdm@v3.1
  with:
    python-version: 3.10
    architecture: x64
    version: 2.7.4
    prerelease: false
    enable-pep582: true
    allow-python-prereleases: false
    cache: true
    token: ***
    cache-dependency-path: pdm.lock
Error: Response code 404 (Not Found)
```

See
https://github.com/apptension/onetimepass/actions/runs/7215237547/job/19659082600?pr=65.