### PR TITLE
Add command to echo database version and file path

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ Initial release after the hackathon
 Fixes all the critical bugs
 
 Optionally:
-- [ ] Add command to echo db version and path
+- [x] Add command to echo db version and path
 
 ## 0.3.0
 

--- a/onetimepass/otp.py
+++ b/onetimepass/otp.py
@@ -536,6 +536,25 @@ def rename(ctx: click.Context, old_alias: str, new_alias: str):
         raise ClickUsageError(f"Alias: {old_alias} does not exist")
 
 
+@otp.command(help="Print the database filepath and (optionally) its version.")
+@click.option(
+    "version",
+    "--version",
+    is_flag=True,
+    help="Include the database version in the output (requires the master key).",
+)
+@click.pass_context
+def db(ctx: click.Context, version: bool):
+    keyring = ctx.obj["keyring_"]
+
+    if version:
+        db = get_decrypted_db(keyring)
+        data = get_db_data(db)
+        click.echo(f"{settings.DB_PATH} (version {data.version})")
+    else:
+        click.echo(settings.DB_PATH)
+
+
 def main():
     otp()
 


### PR DESCRIPTION
Fixes #32.

---

The final interface is slightly different than what was suggested in the related issue. I can't recall my exact reasoning (I implemented that a long time ago; it was waiting for me to finally push it to the repo since then), but it seems to be subjectively more concise and simple than the alternatives. It also works better with the fact that printing the version requires a master key, and printing the file path alone does not—the latter is the default action because of that fact. It also works on the assumption that if someone really needs only the version, they can always pipe the output into something like `| cut -d'(' -f2 | sed 's/)//'`.

I think I wasn't a fan of `db version` because it's inconsistent with `otp --version`, which I plan to introduce at some point. I'm not a fan of `otp version`, as `--version` seems to be preferred in the classic CLIs, and I personally always default to using `--version` or `-v` when trying to fetch a version of any tool. That's opinionated, obviously, but the whole point of `onetimepass` is to be the most comfortable 2FA client for me, primarily, and then for any other potential users.

---

I guess this is also the PR that begins an experiment to gravitate away from naming PRs and commits with nothing more than `Fix #xy`. We'll see how it works.