### PR TITLE
Use the official faster mirror for `black` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,10 @@ repos:
     # In the future, this should be switched to some persistent external storage
     -   id: check-added-large-files
         args: ['--maxkb=1000']
--   repo: https://github.com/psf/black
+    # Using this official mirror over https://github.com/psf/black lets us use
+    # mypyc-compiled `black`, which is about 2x faster; see:
+    # https://black.readthedocs.io/en/stable/integrations/source_version_control.html
+-   repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.12.0
     hooks:
     -   id: black


### PR DESCRIPTION
> ```
> repos:
>   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
>   - repo: https://github.com/psf/black-pre-commit-mirror
> ```
> —https://black.readthedocs.io/en/stable/integrations/source_version_control.html#version-control-integration

See https://github.com/apptension/onetimepass/pull/64#issuecomment-1858831039.