### PR TITLE
Add `--debug` option

### DIFF
--- a/onetimepass/logging.py
+++ b/onetimepass/logging.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 
 from onetimepass import settings
@@ -10,9 +11,10 @@ logger.debug("Hello World")
 ```
 """
 
-logging.basicConfig(
+logging_basic_config = functools.partial(
+    logging.basicConfig,
     format="[%(asctime)s] %(levelname)s:%(module)s:%(lineno)d: %(message)s",
-    level=settings.LOG_LEVEL,
+    level=settings.DEFAULT_LOG_LEVEL,
 )
 
 logger = logging.getLogger(__name__)

--- a/onetimepass/otp.py
+++ b/onetimepass/otp.py
@@ -2,6 +2,7 @@ import binascii
 import datetime
 import functools
 import json
+import logging
 import pathlib
 import time
 from typing import Dict
@@ -32,6 +33,7 @@ from onetimepass.enum import OTPType
 from onetimepass.exceptions import UnhandledFormatException
 from onetimepass.exceptions import UnhandledOTPTypeException
 from onetimepass.logging import logger
+from onetimepass.logging import logging_basic_config
 from onetimepass.otpauth import ParsingError
 from onetimepass.otpauth import Uri
 
@@ -122,10 +124,23 @@ def validation_error_to_str(error: pydantic.ValidationError) -> str:
     default=master_key.MasterKey.keyring_available(),
     show_default="True if keyring installed, False otherwise",
 )
+@click.option(
+    "debug",
+    "-d/-D",
+    "--debug/--no-debug",
+    default=False,
+    show_default=True,
+    help="Enable/disable debug info.",
+)
 @click.pass_context
-def otp(ctx: click.Context, color: bool, quiet: bool, keyring_: bool):
+def otp(ctx: click.Context, color: bool, quiet: bool, keyring_: bool, debug: bool):
     ctx.ensure_object(dict)
     ctx.obj.update({"color": color, "quiet": quiet, "keyring_": keyring_})
+
+    if debug:
+        logging_basic_config(level=logging.DEBUG)
+    else:
+        logging_basic_config()
 
 
 @otp.command(help="Print the one-time password for the specified ALIAS.")

--- a/onetimepass/settings.py
+++ b/onetimepass/settings.py
@@ -17,6 +17,4 @@ DEFAULT_INITIAL_HOTP_COUNTER = 0
 KEYRING_SERVICE_NAME = APP_NAME
 KEYRING_USERNAME = "master key"
 
-LOG_LEVEL = (
-    logging.DEBUG
-)  # TODO change this for the production version OR implement CLI option for that
+DEFAULT_LOG_LEVEL = logging.WARNING


### PR DESCRIPTION
This changes the previously hard-coded log level of `DEBUG` to the one dependent on the option passed by the user: it is either `DEBUG` or (by default) `WARNING` now. The user can enable or disable the debug mode on demand by using the respective flag.