### PR TITLE
Fix error on Linux

### DIFF
--- a/onetimepass/otpauth/schemas.py
+++ b/onetimepass/otpauth/schemas.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import urllib.parse
 from typing import Literal
 from typing import Union

--- a/onetimepass/otpauth/schemas.py
+++ b/onetimepass/otpauth/schemas.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import urllib.parse
 from typing import Literal
 from typing import Union

--- a/onetimepass/otpauth/uri.py
+++ b/onetimepass/otpauth/uri.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import urllib.parse
 from typing import Union
 

--- a/onetimepass/otpauth/uri.py
+++ b/onetimepass/otpauth/uri.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import urllib.parse
 from typing import Union
 


### PR DESCRIPTION
This fixes a Linux-specific error which doesn't appear on macOS:

```
pydantic.errors.ConfigError: Validators defined with incorrect fields:
issuer_must_match_pattern (use check_fields=False if you're inheriting
from the model and intended this)
```